### PR TITLE
sniff file mime type and use it

### DIFF
--- a/gosync/s3.go
+++ b/gosync/s3.go
@@ -4,7 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-
+	"path/filepath"
+	"mime"
 	"github.com/mitchellh/goamz/s3"
 )
 
@@ -47,7 +48,7 @@ func Get(file string, bucket *s3.Bucket, path string) {
 }
 
 func Put(bucket *s3.Bucket, path string, file string) {
-	contType := "binary/octet-stream"
+	contType := mime.TypeByExtension(filepath.Ext(file))
 	Perms := s3.ACL("private")
 
 	data, err := ioutil.ReadFile(file)


### PR DESCRIPTION
Instead of using octet stream use the actual mime type - this is needed for serving web content from aws/cloudfront.
